### PR TITLE
Fix `main` npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "jquery.rateit",
   "version": "1.0.23",
   "description": "Rating plugin for jQuery.",
-  "main": "index.js",
+  "main": "scripts/jquery.rateit.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Adding the correct `main` script in `package.json` so `require()`ing RateIt works in node/browserify.