### PR TITLE
fixed .svg render issue in IE

### DIFF
--- a/scripts/jquery.rateit.js
+++ b/scripts/jquery.rateit.js
@@ -217,6 +217,9 @@
             //resize the height of all elements, 
             if (!isfont) {
                 item.find('.rateit-selected, .rateit-hover').height(itemdata('starheight'));
+                 //added to adjust background image size. added to provide compatibility with IE. IE will not properly 
+                //repeat items unless the background-size is set.
+                item.find('.rateit-selected, .rateit-hover').css('background-size', itemdata('starwidth') + "px " + itemdata('starheight') + "px");
             }
 
 
@@ -239,6 +242,9 @@
             else {
                 //set the range element to fit all the stars.
                 range.width(itemdata('starwidth') * (itemdata('max') - itemdata('min'))).height(itemdata('starheight'));
+                 //added to adjust background image size. added to provide compatibility with IE. IE will not properly 
+                //repeat items unless the background-size is set.
+                range.css('background-size', itemdata('starwidth') + "px " + itemdata('starheight') + "px");
             }
 
 


### PR DESCRIPTION
I'm pretty new to GitHub, so let me know if I messed anything up with reporting this issue and proposing a fix.

When using an .svg file for the star/icon and using IE, the star/icon is not correctly repeated. To make it to repeat correctly, the background-size css property should be set to the "starwidth" and "starheight" values for the .rateit-selected, .rateit-hover, and range elements.

as an example, in IE11, when using an outlined star svg and a filled star svg for the stars, this is how they are rendered:

![image](https://cloud.githubusercontent.com/assets/11825138/23279958/4b569ace-f9e5-11e6-8113-fd1ebed61a88.png)

this can be fixed by setting the background-size, as described above.

![image](https://cloud.githubusercontent.com/assets/11825138/23279987/6942dafc-f9e5-11e6-96bf-b4e5009f04a0.png)


as far as I can tell, this does not impact other major browsers (chrome, firefox, edge)


