### PR TITLE
tabindex="0" gets only added in readonly mode. When keyboard tabbing,…

### DIFF
--- a/scripts/jquery.rateit.js
+++ b/scripts/jquery.rateit.js
@@ -189,7 +189,8 @@
                 var element = item[0].nodeName == 'DIV' ? 'div' : 'span';
                 index++;
 
-                var html = '<button id="rateit-reset-{{index}}" type="button" data-role="none" class="rateit-reset" aria-label="' + $.rateit.aria.resetLabel + '" aria-controls="rateit-range-{{index}}"><span></span></button><{{element}} id="rateit-range-{{index}}" class="rateit-range" tabindex="0" role="slider" aria-label="' + $.rateit.aria.ratingLabel + '" aria-owns="rateit-reset-{{index}}" aria-valuemin="' + itemdata('min') + '" aria-valuemax="' + itemdata('max') + '" aria-valuenow="' + itemdata('value') + '"><{{element}} class="rateit-empty"></{{element}}><{{element}} class="rateit-selected"></{{element}}><{{element}} class="rateit-hover"></{{element}}></{{element}}>';
+                // tabindex="0" gets only added in readonly mode. When keyboard tabbing, no focus is needed in readonly mode.
+                var html = '<button id="rateit-reset-{{index}}" type="button" data-role="none" class="rateit-reset" aria-label="' + $.rateit.aria.resetLabel + '" aria-controls="rateit-range-{{index}}"><span></span></button><{{element}} id="rateit-range-{{index}}" class="rateit-range"' + (itemdata('readonly') == true ? '' : ' tabindex="0"') + ' role="slider" aria-label="' + $.rateit.aria.ratingLabel + '" aria-owns="rateit-reset-{{index}}" aria-valuemin="' + itemdata('min') + '" aria-valuemax="' + itemdata('max') + '" aria-valuenow="' + itemdata('value') + '"><{{element}} class="rateit-empty"></{{element}}><{{element}} class="rateit-selected"></{{element}}><{{element}} class="rateit-hover"></{{element}}></{{element}}>';
                 item.append(html.replace(/{{index}}/gi, index).replace(/{{element}}/gi, element));
 
                 //if we are in RTL mode, we have to change the float of the "reset button"


### PR DESCRIPTION
tabindex="0" gets only added in readonly mode. When keyboard tabbing, no focus is needed in readonly mode.

Fixes issue #22:
https://github.com/gjunge/rateit.js/issues/22

I (We) decided to not just leave the value for tabindex empty, because looking at the documentation it looked like a value of "0" is the default. It is safer to just not add the attribute alltogether in readonly mode.

For some reason both my editors added a newline at the end of the file. I hope that is not a problem.