### PR TITLE
fix bug when using <span> with mode:font

### DIFF
--- a/scripts/rateit.css
+++ b/scripts/rateit.css
@@ -108,7 +108,7 @@
         color: #ccc;
     }
 
-    .rateit-font .rateit-range > div {
+    .rateit-font .rateit-range > div, .rateit-font .rateit-range > span {
         background: none;
         overflow: hidden;
         cursor: default;


### PR DESCRIPTION
This is just a small bugfix for the CSS. When using &lt;span&gt; as container and mode='font' the star images have been visible in the background.