### PR TITLE
Fix deprecated jQuery calls with jQuery 3.5.

### DIFF
--- a/scripts/jquery.rateit.js
+++ b/scripts/jquery.rateit.js
@@ -20,7 +20,7 @@
         if (this.length === 0) { return this; }
 
 
-        var tp1 = $.type(p1);
+        var tp1 = typeof p1;
         if (tp1 == 'object' || p1 === undefined || p1 === null) {
             options = $.extend({}, $.fn.rateit.defaults, p1); //wants to init new rateit plugin(s).
         }
@@ -88,7 +88,7 @@
 
                 //if readonly now and it wasn't readonly, remove the eventhandlers.
                 if (p1 == 'readonly' && p2 == true && !itemdata('readonly')) {
-                    item.find('.rateit-range').unbind();
+                    item.find('.rateit-range').off();
                     itemdata('wired', false);
                 }
                 //when we receive a null value, reset the score to its min value.
@@ -96,7 +96,7 @@
                     p2 = (p2 == null) ? itemdata('min') : Math.max(itemdata('min'), Math.min(itemdata('max'), p2));
                 }
                 if (itemdata('backingfld')) {
-                    //if we have a backing field, check which fields we should update. 
+                    //if we have a backing field, check which fields we should update.
                     //In case of input[type=range], although we did read its attributes even in browsers that don't support it (using fld.attr())
                     //we only update it in browser that support it (&& fld[0].min only works in supporting browsers), not only does it save us from checking if it is range input type, it also is unnecessary.
                     var fld = $(itemdata('backingfld'));
@@ -175,15 +175,15 @@
                         }
                     }
                     else {
-                        //if it is not a select box, we can get's it's value using the val function. 
+                        //if it is not a select box, we can get's it's value using the val function.
                         //If it is a selectbox, we always get a value (the first one of the list), even if it was not explicity set.
                         itemdata('value', fld.val());
                     }
 
-                   
+
                 }
 
-              
+
 
                 //Create the necessary tags. For ARIA purposes we need to give the items an ID. So we use an internal index to create unique ids
                 var element = item[0].nodeName == 'DIV' ? 'div' : 'span';
@@ -212,10 +212,10 @@
 
             var isfont = itemdata('mode') == 'font';
 
-            
 
 
-            //resize the height of all elements, 
+
+            //resize the height of all elements,
             if (!isfont) {
                 item.find('.rateit-selected, .rateit-hover').height(itemdata('starheight'));
             }
@@ -231,9 +231,9 @@
                 for(var i = 0; i< stars; i++){
                     txt += icon;
                 }
-                
+
                 range.find('> *').text(txt);
-                
+
 
                 itemdata('starwidth', range.width() / (itemdata('max') - itemdata('min')))
             }
@@ -261,10 +261,10 @@
             //setup the reset button
             var resetbtn = item.find('.rateit-reset');
             if (resetbtn.data('wired') !== true) {
-                resetbtn.bind('click', function (e) {
+                resetbtn.on('click', function (e) {
                     e.preventDefault();
 
-                    resetbtn.blur();
+                    resetbtn.trigger('blur');
 
                     var event = $.Event('beforereset');
                     item.trigger(event);
@@ -339,27 +339,27 @@
 
                 //when the mouse goes over the range element, we set the "hover" stars.
                 if (!itemdata('wired')) {
-                    range.bind('touchmove touchend', touchHandler); //bind touch events
-                    range.mousemove(function (e) {
+                    range.on('touchmove touchend', touchHandler); //bind touch events
+                    range.on('mousemove', function (e) {
                         var score = calcRawScore(this, e);
                         setHover(score);
                     });
                     //when the mouse leaves the range, we have to hide the hover stars, and show the current value.
-                    range.mouseleave(function (e) {
+                    range.on('mouseleave', function (e) {
                         range.find('.rateit-hover').hide().width(0).data('width', '');
                         item.trigger('hover', [null]).trigger('over', [null]);
                         range.find('.rateit-selected').show();
                     });
                     //when we click on the range, we have to set the value, hide the hover.
-                    range.mouseup(function (e) {
+                    range.on('mouseup', function (e) {
                         var score = calcRawScore(this, e);
                         var value = (score * itemdata('step')) + itemdata('min');
                         setSelection(value);
-                        range.blur();
+                        range.trigger('blur');
                     });
 
                     //support key nav
-                    range.keyup(function (e) {
+                    range.on('keyup', function (e) {
                         if (e.which == 38 || e.which == (ltr ? 39 : 37)) {
                             setSelection(Math.min(itemdata('value') + itemdata('step'), itemdata('max')));
                         }


### PR DESCRIPTION
Fix deprecated jQuery calls with jQuery 3.5.

Hi, with jQuery 3.5 some methods are marked as deprecated. When also loading jquery-migrate.js it will show log messages in the Console of the browser. This PR updates the code to not use those deprecated functions. Works for me :)